### PR TITLE
Implement serde::Serialize and serde::Deserialize for Ksuid structs.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ Cargo.lock
 Session.vim
 
 .env
+
+*.swp

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,12 +14,18 @@ categories = ["data-structures", "concurrency", "database", "encoding"]
 [badges]
 maintenance = {status="actively-developed"}
 
+[features]
+# Include nothing by default
+default = []
+serde = ["dep:serde"]
+
 [dependencies]
 base-encode = "^0.3.1"
 byteorder = "^1.4.3"
 getrandom = "0.2.4"
 time = "0.3.7"
+serde = { version = "^1.0.145", optional = true, features = ["derive"] }
 
 [dev-dependencies]
-serde = { version = "^1.0.133", features = ["derive"] }
-serde_json = "^1.0.74"
+serde = { version = "^1.0.145", features = ["derive"] }
+serde_json = "^1.0.85"

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Add the dependency:
 
 ```toml
 [dependencies]
-svix-ksuid = "^0.5.0"
+svix-ksuid = "^0.6.0"
 ```
 
 ```rust
@@ -61,6 +61,16 @@ let ksuid = KsuidMs::new(None, None);
 ```
 
 And they both implement the same `KsuidLike` trait.
+
+### Opt-in features
+* `serde` - adds the ability to serialize and deserialize `Ksuid` and `KsuidMs`
+  using serde.
+
+Make sure to enable like this:
+```toml
+[dependencies]
+svix-ksuid = { version = "^0.6.0", features = ["serde"] }
+```
 
 ## Examples
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,4 +1,6 @@
 use serde::Deserialize;
+#[cfg(feature = "serde")]
+use serde::Serialize;
 use std::{
     fs::File,
     io::{self, BufRead},
@@ -99,4 +101,51 @@ fn test_ordering() -> Result<(), String> {
     assert!(ksuid2 > ksuid1);
     assert!(ksuid2 >= ksuid1);
     Ok(())
+}
+
+#[cfg(feature = "serde")]
+#[derive(Serialize, Deserialize)]
+struct TestKsuid {
+    id: Ksuid,
+}
+
+#[cfg(feature = "serde")]
+#[derive(Serialize, Deserialize)]
+struct TestKsuidMs {
+    id: KsuidMs,
+}
+
+#[cfg(feature = "serde")]
+#[test]
+fn test_serialize_to_base62() {
+    let b62 = "1srOrx2ZWZBpBUvZwXKQmoEYga2";
+    let json = r#"{"id":"1srOrx2ZWZBpBUvZwXKQmoEYga2"}"#;
+    let ksuid_obj = TestKsuid {
+        id: Ksuid::from_base62(b62).unwrap(),
+    };
+    let ksuidms_obj = TestKsuidMs {
+        id: KsuidMs::from_base62(b62).unwrap(),
+    };
+
+    let test_cases = vec![
+        serde_json::to_string(&ksuid_obj),
+        serde_json::to_string(&ksuidms_obj),
+    ];
+    for serialized in test_cases {
+        assert!(serialized.is_ok());
+        let serialized = serialized.unwrap();
+        assert_eq!(serialized, json);
+    }
+}
+
+#[cfg(feature = "serde")]
+#[test]
+fn test_deserialize_from_base62() {
+    let b62 = "1srOrx2ZWZBpBUvZwXKQmoEYga2";
+    let json = r#"{"id":"1srOrx2ZWZBpBUvZwXKQmoEYga2"}"#;
+
+    let ksuid_obj: TestKsuid = serde_json::from_str(json).unwrap();
+    let ksuidms_obj: TestKsuidMs = serde_json::from_str(json).unwrap();
+    assert_eq!(ksuid_obj.id.to_string(), b62);
+    assert_eq!(ksuidms_obj.id.to_string(), b62);
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
1. as a `rust-ksuid` lib user I want to serialize to JSON structs that use Ksuid type
2. as a `rust-ksuid` lib user I want to deserialize from JSON to structs that use Ksuid type
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution
Implement serde::Serialize and serde::Deserialize for Ksuid structs.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
