### PR TITLE
fix: do not parse base62 strings of unexpected length

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,6 +76,7 @@ pub const KSUID_EPOCH: i64 = 1_400_000_000;
 const BASE_62_CHARS: &[u8; 62] = b"0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
 
 const TOTAL_BYTES: usize = 20;
+const TOTAL_BYTES_BASE62: usize = 27;
 
 #[derive(Debug)]
 pub struct Error(String);
@@ -237,6 +238,12 @@ pub trait KsuidLike {
     ///
     /// ```
     fn from_base62(s: &str) -> Result<Self::Type, Error> {
+        if s.len() != TOTAL_BYTES_BASE62 {
+            return Err(Error(format!(
+                "Got base62 ksuid of unexpected length {}",
+                s.len()
+            )));
+        }
         if let Some(loaded) = base_encode::from_str(s, 62, BASE_62_CHARS) {
             // Get the last TOTAL_BYTES
             let loaded = if loaded.len() > TOTAL_BYTES {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -203,3 +203,15 @@ fn test_deserialize_from_base62() {
     assert_eq!(ksuid_obj.id.to_string(), b62);
     assert_eq!(ksuidms_obj.id.to_string(), b62);
 }
+
+#[test]
+fn test_deserialize_bad_base62_length() {
+    let short_b62 = "ZBpBUvZwXKQmoEYga2";
+    let long_b62 = "1srOrx2ZWZBpBUvZwXKQmoEYga21srOrx2ZWZBpBUvZwXKQmoEYga2";
+
+    let result = Ksuid::from_base62(short_b62);
+    assert!(result.is_err(), "Short base62 strings should fail to parse");
+
+    let result = Ksuid::from_base62(long_b62);
+    assert!(result.is_err(), "Long base62 strings should fail to parse");
+}


### PR DESCRIPTION
## Motivation

I noticed that from_base62 would accept inputs of arbitrary length and decode them from base62 instead of validating length ahead of time. Further, if a KSUID decoded to an excessively long string of bytes, it would quietly accept this and only copy the remaining 20 bytes of data. As a result, this meant that rust-ksuid would accept strings of invalid length instead of rejecting them [like the Segment KSUID implementation](https://go.dev/play/p/Ug3ug9f2Mzs).

I'm unclear if this is a behavior that rust-ksuid users depend on, so maybe should have a default-on `strict` crate feature (or, preferably, `nonstrict` that's off by default) so users have to opt into parsing invalid KSUIDs. If that's the right path forward, users should probably also be made aware that rust-ksuid might allocate much more memory than is needed for decoding a KSUID. I have a feeling this isn't a great way to OOM code that uses the crate, but sending enough unusually long KSUIDs might pose a risk to those applications from either memory allocation or consuming time decoding long base62 strings.

## Solution

Before decoding any base62 string, check that the string's input length is 27 bytes and add tests to verify long and short strings are still invalid.