### PR TITLE
deps: bump getrandom from 0.2 to 0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ serde = ["dep:serde"]
 [dependencies]
 base-encode = "^0.3.1"
 byteorder = "^1.4.3"
-getrandom = "0.2.4"
+getrandom = "0.4.2"
 time = "0.3.7"
 serde = { version = "^1.0.145", optional = true, features = ["derive"] }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -299,7 +299,7 @@ impl Ksuid {
         if let Some(payload) = payload {
             buf[Self::TIMESTAMP_BYTES..].copy_from_slice(payload);
         } else {
-            getrandom::getrandom(&mut buf[Self::TIMESTAMP_BYTES..]).unwrap();
+            getrandom::fill(&mut buf[Self::TIMESTAMP_BYTES..]).unwrap();
         }
         Self::from_bytes(buf)
     }
@@ -408,7 +408,7 @@ impl KsuidMs {
         if let Some(payload) = payload {
             buf[Self::TIMESTAMP_BYTES..].copy_from_slice(payload);
         } else {
-            getrandom::getrandom(&mut buf[Self::TIMESTAMP_BYTES..]).unwrap();
+            getrandom::fill(&mut buf[Self::TIMESTAMP_BYTES..]).unwrap();
         }
         Self::from_bytes(buf)
     }


### PR DESCRIPTION
Noticed that this was way behind when upgrading `rand` in one of the other repos.