### PR TITLE
feat: support multiple time crates

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -35,3 +35,9 @@ jobs:
         run: cargo test --all --no-default-features --all-targets
       - name: Run doc tests
         run: cargo test --doc
+      - name: Run tests (jiff02)
+        run: cargo test --all --no-default-features --features "jiff02" --all-targets
+      - name: Run tests (chrono04)
+        run: cargo test --all --no-default-features --features "chrono04" --all-targets
+      - name: Run tests (time03)
+        run: cargo test --all --no-default-features --features "time03" --all-targets

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,72 +1,37 @@
 name: CI
-
 on:
   push:
     branches:
-    - main
+      - main
   pull_request: {}
-
 jobs:
-  check:
-    # Run `cargo check` first to ensure that the pushed code at least compiles.
+  lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: nightly
-        override: true
-        profile: minimal
-        components: clippy, rustfmt
-    - uses: Swatinem/rust-cache@v1
-    - name: Check
-      uses: actions-rs/cargo@v1
-      with:
-        command: clippy
-        args: --all --all-targets --all-features
-    - name: rustfmt
-      uses: actions-rs/cargo@v1
-      with:
-        command: fmt
-        args: --all -- --check
-
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly
+          components: clippy, rustfmt
+      - uses: Swatinem/rust-cache@v1
+      - name: clippy
+        run: cargo clippy --all --all-targets --all-features
+      - name: rustfmt
+        run: cargo fmt --all -- --check
   test-versions:
-    needs: check
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: [stable, beta]
+        rust: ["1.88.0", stable, beta]
     steps:
-    - uses: actions/checkout@master
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: ${{ matrix.rust }}
-        override: true
-        profile: minimal
-    - uses: Swatinem/rust-cache@v1
-    - name: Run tests
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: --all --all-features --all-targets
-    - name: Run doc tests
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: --doc
-
-#  deny-check:
-#    name: cargo-deny check
-#    runs-on: ubuntu-latest
-#    continue-on-error: ${{ matrix.checks == 'advisories' }}
-#    strategy:
-#      matrix:
-#        checks:
-#          - advisories
-#          - bans licenses sources
-#    steps:
-#      - uses: actions/checkout@v2
-#      - uses: EmbarkStudios/cargo-deny-action@v1
-#        with:
-#          command: check ${{ matrix.checks }}
-#          arguments: --all-features --manifest-path axum/Cargo.toml
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.rust }}
+      - uses: Swatinem/rust-cache@v2
+      - name: Run tests (all features)
+        run: cargo test --all --all-features --all-targets
+      - name: Run tests (no features)
+        run: cargo test --all --no-default-features --all-targets
+      - name: Run doc tests
+        run: cargo test --doc

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,9 +15,6 @@ jobs:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-        with:
-          # only restore cache for faster publishing, don't save back results
-          save-if: "false"
       - uses: rust-lang/crates-io-auth-action@v1
         id: auth
       - name: Publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,33 +1,25 @@
 name: Release
-
 env:
   CARGO_TERM_COLOR: always
-
 on:
   push:
     tags:
       - 'v*'
-
 jobs:
   build:
     runs-on: ubuntu-latest
     environment: release
-
     permissions:
       id-token: write
-
     steps:
       - uses: actions/checkout@v6
-
       - uses: dtolnay/rust-toolchain@stable
-
       - uses: Swatinem/rust-cache@v2
-        # only restore cache for faster publishing, don't save back results
-        save-if: false
-
+        with:
+          # only restore cache for faster publishing, don't save back results
+          save-if: "false"
       - uses: rust-lang/crates-io-auth-action@v1
         id: auth
-
       - name: Publish
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,22 +1,19 @@
 name: Security
-
 on:
   push:
     branches:
-    - main
-    paths:
-      - '**/Cargo.toml'
-      - '**/Cargo.lock'
+      - main
   pull_request:
     paths:
       - '**/Cargo.toml'
       - '**/Cargo.lock'
-
+      - 'deny.toml'
 jobs:
-  security_audit:
+  cargo-deny:
+    name: cargo-deny check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions-rs/audit-check@v1
+      - uses: actions/checkout@v6
+      - uses: EmbarkStudios/cargo-deny-action@v2
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          manifest-path: Cargo.toml

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,8 @@
 name = "svix-ksuid"
 version = "0.8.0"
 authors = ["Svix Inc. <oss@svix.com>"]
-edition = "2021"
+edition = "2024"
+rust-version = "1.88"
 description="A pure Rust and fully tested KSUID implementation"
 homepage="https://www.svix.com"
 repository="https://github.com/svix/rust-ksuid"
@@ -15,15 +16,20 @@ categories = ["data-structures", "concurrency", "database", "encoding"]
 maintenance = {status="actively-developed"}
 
 [features]
-# Include nothing by default
-default = []
+# Include `time` by default, to match old behavior
+default = ["time03"]
 serde = ["dep:serde"]
+jiff02 = ["dep:jiff"]
+time03 = ["dep:time"]
+chrono04 = ["dep:chrono"]
 
 [dependencies]
 base-encode = "^0.3.1"
 byteorder = "^1.4.3"
 getrandom = "0.4.2"
-time = "0.3.7"
+time = { version = "0.3.47", optional = true }
+chrono = { version = "0.4", optional = true }
+jiff = { version = "0.2", optional = true }
 serde = { version = "^1.0.145", optional = true, features = ["derive"] }
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ For the Python version, please check out https://github.com/svix/python-ksuid
 
 ## What is a ksuid?
 
-A ksuid is a K sorted UID. In other words, a KSUID also stores a date component, so that ksuids can be approximately 
-sorted based on the time they were created. 
+A ksuid is a K sorted UID. In other words, a KSUID also stores a date component, so that ksuids can be approximately
+sorted based on the time they were created.
 
 Read more [here](https://segment.com/blog/a-brief-history-of-the-uuid/).
 
@@ -41,7 +41,7 @@ svix-ksuid = "^0.6.0"
 ```rust
 use svix_ksuid::*;
 
-let ksuid = Ksuid::new(None, None);
+let ksuid = Ksuid::now(None);
 println!("{}", ksuid.to_string());
 // 1srOrx2ZWZBpBUvZwXKQmoEYga2
 ```
@@ -57,7 +57,7 @@ The code too is fully compatible:
 ```rust
 use svix_ksuid::*;
 
-let ksuid = KsuidMs::new(None, None);
+let ksuid = KsuidMs::now(None);
 ```
 
 And they both implement the same `KsuidLike` trait.
@@ -65,11 +65,14 @@ And they both implement the same `KsuidLike` trait.
 ### Opt-in features
 * `serde` - adds the ability to serialize and deserialize `Ksuid` and `KsuidMs`
   using serde.
+* `time03` - accept timestamps as the `time::OffsetDateTime` type from the [time](https://crates.io/crates/time) (0.3.x) crate &ndash; this feature is enabled by default, for compatibility with 0.8.x and older verisons
+* `chrono04` - accept timestamps as the `chrono::DateTime<chrono::Utc>` type from the [chrono](https://crates.io/crates/chrono) (0.4.x) crate
+* `jiff02` - accept timestamps as the `jiff::Timestamp` type from the [jiff](https://crates.io/crates/jiff) (0.2.x) crate
 
 Make sure to enable like this:
 ```toml
 [dependencies]
-svix-ksuid = { version = "^0.6.0", features = ["serde"] }
+svix-ksuid = { version = "^0.6.0", features = ["serde", "jiff02"] }
 ```
 
 ## Examples
@@ -79,7 +82,7 @@ svix-ksuid = { version = "^0.6.0", features = ["serde"] }
 ```rust
 use svix_ksuid::*;
 
-let ksuid = Ksuid::new(None, None);
+let ksuid = Ksuid::now(None);
 
 // Base62
 println!("{}", ksuid.to_string()); // also: ksuid.to_base62()
@@ -90,7 +93,7 @@ println!("{:?}", ksuid.bytes());
 // [13, 53, 196, 51, 225, 147, 62, 55, 242, 117, 112, 135, 99, 173, 199, 116, 90, 245, 231, 242]
 
 // Timestamp (time::OffsetDateTime)
-println!("{:?}", ksuid.timestamp());
+println!("{:?}", ksuid.timestamp::<time::OffsetDateTime>());
 // 2021-05-21T20:04:03Z
 
 // Timestamp (seconds)
@@ -106,9 +109,10 @@ println!("{:?}", ksuid.bytes());
 
 ```rust
 use svix_ksuid::*;
+use chrono::Utc;
 
 // Timestamp is now, payload is randomly generated
-let ksuid = Ksuid::new(None, None);
+let ksuid = Ksuid::now(None);
 
 // Explicitly set either
 let bytes = [12u8; Ksuid::PAYLOAD_BYTES];

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,58 @@
+[graph]
+targets = [
+    { triple = "x86_64-pc-windows-gnu" },
+    { triple = "x86_64-unknown-linux-musl" },
+    { triple = "x86_64-apple-darwin" },
+    { triple = "aarch64-apple-darwin" },
+]
+
+[advisories]
+db-path = "~/.cargo/advisory-db"
+db-urls = ["https://github.com/rustsec/advisory-db"]
+yanked = "deny"
+ignore = [
+]
+
+[licenses]
+allow = [
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "CC0-1.0",
+    "ISC",
+    "MIT",
+    "MPL-2.0",
+    "Unicode-3.0",
+    "Zlib",
+]
+unused-allowed-license = "allow"
+confidence-threshold = 0.8
+exceptions = [
+]
+
+# TODO: Include internal crates
+[licenses.private]
+ignore = false
+registries = []
+
+[bans]
+multiple-versions = "allow"
+wildcards = "allow"
+highlight = "all"
+allow = []
+deny = [
+    # Versions containing the binary blob
+    # See: https://github.com/serde-rs/serde/issues/2538
+    { name = "serde_derive", version = ">1.0.171, <1.0.184"},
+]
+skip = []
+skip-tree = []
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = [
+]
+# there are several projects in here, so it's okay if we don't use them all

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -234,22 +234,6 @@ impl TimeStamp for MinimalTimestamp {
     }
 }
 
-#[cfg(feature = "jiff02")]
-pub type DefaultTimestamp = jiff::Timestamp;
-
-#[cfg(all(not(feature = "jiff02"), feature = "chrono04"))]
-pub type DefaultTimestamp = chrono::Timestamp;
-
-#[cfg(all(not(feature = "jiff02"), not(feature = "chrono04"), feature = "time03"))]
-pub type DefaultTimestamp = time::OffsetDateTime;
-
-#[cfg(all(
-    not(feature = "jiff02"),
-    not(feature = "chrono04"),
-    not(feature = "time03")
-))]
-pub type DefaultTimestamp = MinimalTimestamp;
-
 /// K-Sortable Unique ID Trait
 ///
 /// This trait is implemented by all of the ksuid variants
@@ -279,7 +263,7 @@ pub trait KsuidLike {
     /// ```
     /// use svix_ksuid::*;
     ///
-    /// let ts = DefaultTimestamp::from_millis(1776798415000).unwrap();
+    /// let ts = MinimalTimestamp::from_millis(1776798415000).unwrap();
     /// let ksuid = Ksuid::new(Some(ts), None);
     /// ```
     fn new<T: TimeStamp>(timestamp: Option<T>, payload: Option<&[u8]>) -> Self::Type;
@@ -293,7 +277,7 @@ pub trait KsuidLike {
     /// let ksuid = Ksuid::now(None);
     /// ```
     fn now(payload: Option<&[u8]>) -> Self::Type {
-        Self::new(None::<DefaultTimestamp>, payload)
+        Self::new(None::<MinimalTimestamp>, payload)
     }
 
     /// Creates new Ksuid with specified timestamp (in seconds) and optional payload
@@ -312,9 +296,9 @@ pub trait KsuidLike {
     /// ```
     /// use svix_ksuid::*;
     ///
-    /// let now = DefaultTimestamp::now();
+    /// let now = MinimalTimestamp::now();
     /// let ksuid = Ksuid::new(Some(now), None);
-    /// assert_eq!(now.as_secs(), ksuid.timestamp::<DefaultTimestamp>().as_secs());
+    /// assert_eq!(now.as_secs(), ksuid.timestamp::<MinimalTimestamp>().as_secs());
     /// ```
     fn timestamp<T: TimeStamp>(&self) -> T;
 
@@ -329,7 +313,7 @@ pub trait KsuidLike {
     /// assert_eq!(ksuid.timestamp_seconds(), timestamp);
     /// ```
     fn timestamp_seconds(&self) -> i64 {
-        self.timestamp::<DefaultTimestamp>().as_secs()
+        self.timestamp::<MinimalTimestamp>().as_secs()
     }
 
     /// Get the payload portion of the ksuid
@@ -476,7 +460,7 @@ impl Ksuid {
     /// ```
     /// use svix_ksuid::*;
     ///
-    /// let ts = DefaultTimestamp::from_millis(1776798415000).unwrap();
+    /// let ts = MinimalTimestamp::from_millis(1776798415000).unwrap();
     /// let ksuid = Ksuid::new(Some(ts), None);
     /// let raw = ksuid.timestamp_raw();
     /// ```
@@ -497,7 +481,7 @@ impl KsuidLike for Ksuid {
 
     fn from_seconds(timestamp: Option<i64>, payload: Option<&[u8]>) -> Self {
         let timestamp =
-            timestamp.unwrap_or_else(|| DefaultTimestamp::now().as_secs()) - KSUID_EPOCH;
+            timestamp.unwrap_or_else(|| MinimalTimestamp::now().as_secs()) - KSUID_EPOCH;
         Self::new_raw(timestamp as u32, payload)
     }
 
@@ -588,7 +572,7 @@ impl KsuidMs {
     /// let ksuid = KsuidMs::from_millis(Some(1_621_627_443_000), None);
     /// ```
     pub fn from_millis(timestamp: Option<i64>, payload: Option<&[u8]>) -> Self {
-        let timestamp_ms = timestamp.unwrap_or_else(|| DefaultTimestamp::now().as_millis());
+        let timestamp_ms = timestamp.unwrap_or_else(|| MinimalTimestamp::now().as_millis());
         let timestamp_s = (timestamp_ms / 1_000) - KSUID_EPOCH;
         let timestamp_ms = (timestamp_ms % 1_000) >> 2;
         let timestamp = ((timestamp_s << 8) & 0xFFFFFFFF00) | timestamp_ms;
@@ -606,7 +590,7 @@ impl KsuidMs {
     /// assert_eq!(ksuid.timestamp_millis(), timestamp);
     /// ```
     pub fn timestamp_millis(&self) -> i64 {
-        self.timestamp::<DefaultTimestamp>().as_millis()
+        self.timestamp::<MinimalTimestamp>().as_millis()
     }
 
     /// Get the raw timestamp value of the ksuid

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -242,7 +242,7 @@ impl TimeStamp for MinimalTimestamp {
 type DefaultTimestamp = jiff::Timestamp;
 
 #[cfg(all(not(feature = "jiff02"), feature = "chrono04"))]
-type DefaultTimestamp = chrono::Timestamp;
+type DefaultTimestamp = chrono::DateTime<chrono::Utc>;
 
 #[cfg(all(not(feature = "jiff02"), not(feature = "chrono04"), feature = "time03"))]
 type DefaultTimestamp = time::OffsetDateTime;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@
 //! ```
 //! use svix_ksuid::*;
 //!
-//! let ksuid = Ksuid::new(None, None);
+//! let ksuid = Ksuid::now(None);
 //! println!("{}", ksuid.to_string());
 //! // 1srOrx2ZWZBpBUvZwXKQmoEYga2
 //! ```
@@ -38,7 +38,7 @@
 //! ```
 //! use svix_ksuid::*;
 //!
-//! let ksuid = KsuidMs::new(None, None);
+//! let ksuid = KsuidMs::now(None);
 //! ```
 //!
 //! And they both implement the same `KsuidLike` trait.
@@ -46,11 +46,14 @@
 //! ### Opt-in features
 //! * `serde` - adds the ability to serialize and deserialize `Ksuid` and `KsuidMs`
 //!   using serde.
+//! * `time03` - accept timestamps as the [`time::OffsetDateTime`] type from the time (0.3.x) crate
+//! * `chrono04` - accept timestamps as the [`chrono::DateTime<chrono::Utc>`] type from the chrono (0.4.x) crate
+//! * `jiff02` - accept timestamps as the [`jiff::Timestamp`] type from the jiff (0.2.x) crate
 //!
 //! Make sure to enable like this:
 //! ```toml
 //! [dependencies]
-//! svix-ksuid = { version = "^0.6.0", features = ["serde"] }
+//! svix-ksuid = { version = "^0.6.0", features = ["serde", "time03", "jiff02"] }
 //! ```
 //!
 //! ### License
@@ -64,7 +67,6 @@ use std::hash::{Hash, Hasher};
 use std::{error, str::FromStr};
 
 use byteorder::{BigEndian, ByteOrder};
-use time::OffsetDateTime;
 
 #[cfg(feature = "serde")]
 use serde::de::{self, Deserialize, Deserializer, Visitor};
@@ -93,9 +95,160 @@ impl error::Error for Error {
     }
 }
 
-fn timestamp_millis(dt: &OffsetDateTime) -> i64 {
-    (dt.unix_timestamp_nanos() / 1_000_000) as i64
+pub trait TimeStamp: Sized {
+    type ConstructionError: std::error::Error + Sized;
+
+    fn now() -> Self;
+
+    fn from_millis(val: i64) -> Result<Self, Self::ConstructionError>;
+
+    fn from_secs(val: i64) -> Result<Self, Self::ConstructionError> {
+        Self::from_millis(val * 1_000)
+    }
+
+    fn as_millis(&self) -> i64;
+
+    fn as_secs(&self) -> i64 {
+        self.as_millis() / 1_000
+    }
 }
+
+#[cfg(feature = "time03")]
+impl TimeStamp for time::OffsetDateTime {
+    type ConstructionError = time::error::ComponentRange;
+
+    fn now() -> Self {
+        time::OffsetDateTime::now_utc()
+    }
+
+    fn from_millis(val: i64) -> Result<Self, Self::ConstructionError> {
+        time::OffsetDateTime::from_unix_timestamp_nanos(val as i128 * 1_000_000)
+    }
+
+    fn from_secs(val: i64) -> Result<Self, Self::ConstructionError> {
+        time::OffsetDateTime::from_unix_timestamp(val)
+    }
+
+    fn as_millis(&self) -> i64 {
+        (self.unix_timestamp_nanos() / 1_000_000) as _
+    }
+
+    fn as_secs(&self) -> i64 {
+        self.unix_timestamp()
+    }
+}
+
+#[cfg(feature = "chrono04")]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum InvalidChronoTimestamp {
+    OutOfRange,
+}
+
+#[cfg(feature = "chrono04")]
+impl std::fmt::Display for InvalidChronoTimestamp {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "invalid timestamp for chrono time implementation")
+    }
+}
+
+#[cfg(feature = "chrono04")]
+impl std::error::Error for InvalidChronoTimestamp {
+    fn description(&self) -> &str {
+        "invalid timestamp for chrono time implementation"
+    }
+
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+        None
+    }
+}
+
+#[cfg(feature = "chrono04")]
+impl TimeStamp for chrono::DateTime<chrono::Utc> {
+    type ConstructionError = InvalidChronoTimestamp;
+
+    fn now() -> Self {
+        chrono::Utc::now()
+    }
+
+    fn from_millis(val: i64) -> Result<Self, Self::ConstructionError> {
+        chrono::DateTime::from_timestamp_millis(val).ok_or(InvalidChronoTimestamp::OutOfRange)
+    }
+
+    fn from_secs(val: i64) -> Result<Self, Self::ConstructionError> {
+        chrono::DateTime::from_timestamp(val, 0).ok_or(InvalidChronoTimestamp::OutOfRange)
+    }
+
+    fn as_millis(&self) -> i64 {
+        self.timestamp_millis()
+    }
+
+    fn as_secs(&self) -> i64 {
+        self.timestamp()
+    }
+}
+
+#[cfg(feature = "jiff02")]
+impl TimeStamp for jiff::Timestamp {
+    type ConstructionError = jiff::Error;
+
+    fn now() -> Self {
+        jiff::Timestamp::now()
+    }
+
+    fn from_millis(val: i64) -> Result<Self, Self::ConstructionError> {
+        jiff::Timestamp::from_millisecond(val)
+    }
+
+    fn from_secs(val: i64) -> Result<Self, Self::ConstructionError> {
+        jiff::Timestamp::from_second(val)
+    }
+
+    fn as_millis(&self) -> i64 {
+        self.as_millisecond()
+    }
+
+    fn as_secs(&self) -> i64 {
+        self.as_second()
+    }
+}
+
+#[allow(unused)]
+/// A minimal representation of a timestamp (as integral milliseconds since UNIX_EPOCH) suitable
+/// for use if none of jiff02, chrono04, nor time03 are enabled
+#[derive(Debug, Clone, Copy, PartialOrd, Ord, PartialEq, Eq)]
+pub struct MinimalTimestamp(i64);
+
+impl TimeStamp for MinimalTimestamp {
+    type ConstructionError = std::convert::Infallible;
+
+    fn now() -> Self {
+        Self(std::time::UNIX_EPOCH.elapsed().unwrap().as_millis() as _)
+    }
+
+    fn from_millis(val: i64) -> Result<Self, std::convert::Infallible> {
+        Ok(Self(val))
+    }
+
+    fn as_millis(&self) -> i64 {
+        self.0
+    }
+}
+
+#[cfg(feature = "jiff02")]
+pub type DefaultTimestamp = jiff::Timestamp;
+
+#[cfg(all(not(feature = "jiff02"), feature = "chrono04"))]
+pub type DefaultTimestamp = chrono::Timestamp;
+
+#[cfg(all(not(feature = "jiff02"), not(feature = "chrono04"), feature = "time03"))]
+pub type DefaultTimestamp = time::OffsetDateTime;
+
+#[cfg(all(
+    not(feature = "jiff02"),
+    not(feature = "chrono04"),
+    not(feature = "time03")
+))]
+pub type DefaultTimestamp = MinimalTimestamp;
 
 /// K-Sortable Unique ID Trait
 ///
@@ -106,7 +259,7 @@ fn timestamp_millis(dt: &OffsetDateTime) -> i64 {
 /// use svix_ksuid::*;
 /// use std::str::FromStr;
 ///
-/// let ksuid = Ksuid::new(None, None);
+/// let ksuid = Ksuid::now(None);
 /// let as_string: String = ksuid.to_string();
 /// let ksuid2 = Ksuid::from_str(&as_string).unwrap();
 /// assert_eq!(ksuid, ksuid2);
@@ -126,9 +279,22 @@ pub trait KsuidLike {
     /// ```
     /// use svix_ksuid::*;
     ///
-    /// let ksuid = Ksuid::new(None, None);
+    /// let ts = DefaultTimestamp::from_millis(1776798415000).unwrap();
+    /// let ksuid = Ksuid::new(Some(ts), None);
     /// ```
-    fn new(timestamp: Option<OffsetDateTime>, payload: Option<&[u8]>) -> Self::Type;
+    fn new<T: TimeStamp>(timestamp: Option<T>, payload: Option<&[u8]>) -> Self::Type;
+
+    /// Creates a new Ksuid at the current timestamp, with an optional payload
+    ///
+    /// # Examples
+    /// ```
+    /// use svix_ksuid::*;
+    ///
+    /// let ksuid = Ksuid::now(None);
+    /// ```
+    fn now(payload: Option<&[u8]>) -> Self::Type {
+        Self::new(None::<DefaultTimestamp>, payload)
+    }
 
     /// Creates new Ksuid with specified timestamp (in seconds) and optional payload
     ///
@@ -145,13 +311,12 @@ pub trait KsuidLike {
     /// # Examples
     /// ```
     /// use svix_ksuid::*;
-    /// use time::OffsetDateTime;
     ///
-    /// let now = OffsetDateTime::now_utc();
+    /// let now = DefaultTimestamp::now();
     /// let ksuid = Ksuid::new(Some(now), None);
-    /// assert_eq!(now.unix_timestamp(), ksuid.timestamp().unix_timestamp());
+    /// assert_eq!(now.as_secs(), ksuid.timestamp::<DefaultTimestamp>().as_secs());
     /// ```
-    fn timestamp(&self) -> OffsetDateTime;
+    fn timestamp<T: TimeStamp>(&self) -> T;
 
     /// Get the timestamp portion of the ksuid in seconds
     ///
@@ -164,7 +329,7 @@ pub trait KsuidLike {
     /// assert_eq!(ksuid.timestamp_seconds(), timestamp);
     /// ```
     fn timestamp_seconds(&self) -> i64 {
-        self.timestamp().unix_timestamp()
+        self.timestamp::<DefaultTimestamp>().as_secs()
     }
 
     /// Get the payload portion of the ksuid
@@ -174,7 +339,7 @@ pub trait KsuidLike {
     /// use svix_ksuid::*;
     ///
     /// let buf = b"1234567890ABCDEF";
-    /// let ksuid = Ksuid::new(None, Some(&buf[..]));
+    /// let ksuid = Ksuid::now(Some(&buf[..]));
     /// assert_eq!(ksuid.payload(), &buf[..]);
     /// ```
     fn payload(&self) -> &[u8] {
@@ -276,7 +441,7 @@ pub trait KsuidLike {
 /// use svix_ksuid::*;
 /// use std::str::FromStr;
 ///
-/// let ksuid = Ksuid::new(None, None);
+/// let ksuid = Ksuid::now(None);
 /// let as_string: String = ksuid.to_string();
 /// let ksuid2 = Ksuid::from_str(&as_string).unwrap();
 /// assert_eq!(ksuid, ksuid2);
@@ -311,7 +476,8 @@ impl Ksuid {
     /// ```
     /// use svix_ksuid::*;
     ///
-    /// let ksuid = Ksuid::new(None, None);
+    /// let ts = DefaultTimestamp::from_millis(1776798415000).unwrap();
+    /// let ksuid = Ksuid::new(Some(ts), None);
     /// let raw = ksuid.timestamp_raw();
     /// ```
     pub fn timestamp_raw(&self) -> u32 {
@@ -324,14 +490,14 @@ impl KsuidLike for Ksuid {
     const TIMESTAMP_BYTES: usize = 4;
     const PAYLOAD_BYTES: usize = 16;
 
-    fn new(timestamp: Option<OffsetDateTime>, payload: Option<&[u8]>) -> Self {
-        let timestamp = timestamp.map(|x| x.unix_timestamp());
+    fn new<T: TimeStamp>(timestamp: Option<T>, payload: Option<&[u8]>) -> Self {
+        let timestamp = timestamp.map(|x| x.as_secs());
         Self::from_seconds(timestamp, payload)
     }
 
     fn from_seconds(timestamp: Option<i64>, payload: Option<&[u8]>) -> Self {
         let timestamp =
-            timestamp.unwrap_or_else(|| OffsetDateTime::now_utc().unix_timestamp()) - KSUID_EPOCH;
+            timestamp.unwrap_or_else(|| DefaultTimestamp::now().as_secs()) - KSUID_EPOCH;
         Self::new_raw(timestamp as u32, payload)
     }
 
@@ -343,9 +509,9 @@ impl KsuidLike for Ksuid {
         &self.0
     }
 
-    fn timestamp(&self) -> OffsetDateTime {
+    fn timestamp<T: TimeStamp>(&self) -> T {
         let timestamp = self.timestamp_raw() as i64 + KSUID_EPOCH;
-        OffsetDateTime::from_unix_timestamp(timestamp).unwrap()
+        T::from_secs(timestamp).unwrap()
     }
 }
 
@@ -378,7 +544,7 @@ impl Hash for Ksuid {
 /// use svix_ksuid::*;
 /// use std::str::FromStr;
 ///
-/// let ksuid = KsuidMs::new(None, None);
+/// let ksuid = KsuidMs::now(None);
 /// let as_string: String = ksuid.to_string();
 /// let ksuid2 = KsuidMs::from_str(&as_string).unwrap();
 /// assert_eq!(ksuid, ksuid2);
@@ -422,8 +588,7 @@ impl KsuidMs {
     /// let ksuid = KsuidMs::from_millis(Some(1_621_627_443_000), None);
     /// ```
     pub fn from_millis(timestamp: Option<i64>, payload: Option<&[u8]>) -> Self {
-        let timestamp_ms =
-            timestamp.unwrap_or_else(|| timestamp_millis(&OffsetDateTime::now_utc()));
+        let timestamp_ms = timestamp.unwrap_or_else(|| DefaultTimestamp::now().as_millis());
         let timestamp_s = (timestamp_ms / 1_000) - KSUID_EPOCH;
         let timestamp_ms = (timestamp_ms % 1_000) >> 2;
         let timestamp = ((timestamp_s << 8) & 0xFFFFFFFF00) | timestamp_ms;
@@ -441,7 +606,7 @@ impl KsuidMs {
     /// assert_eq!(ksuid.timestamp_millis(), timestamp);
     /// ```
     pub fn timestamp_millis(&self) -> i64 {
-        timestamp_millis(&self.timestamp())
+        self.timestamp::<DefaultTimestamp>().as_millis()
     }
 
     /// Get the raw timestamp value of the ksuid
@@ -452,7 +617,7 @@ impl KsuidMs {
     /// ```
     /// use svix_ksuid::*;
     ///
-    /// let ksuid = Ksuid::new(None, None);
+    /// let ksuid = Ksuid::now(None);
     /// let raw = ksuid.timestamp_raw();
     /// ```
     pub fn timestamp_raw(&self) -> u64 {
@@ -466,8 +631,8 @@ impl KsuidLike for KsuidMs {
     const TIMESTAMP_BYTES: usize = 5;
     const PAYLOAD_BYTES: usize = 15;
 
-    fn new(timestamp: Option<OffsetDateTime>, payload: Option<&[u8]>) -> Self {
-        let timestamp = timestamp.map(|x| timestamp_millis(&x));
+    fn new<T: TimeStamp>(timestamp: Option<T>, payload: Option<&[u8]>) -> Self {
+        let timestamp = timestamp.map(|x| x.as_millis());
         Self::from_millis(timestamp, payload)
     }
 
@@ -484,12 +649,13 @@ impl KsuidLike for KsuidMs {
         &self.0
     }
 
-    fn timestamp(&self) -> OffsetDateTime {
+    fn timestamp<T: TimeStamp>(&self) -> T {
         let timestamp = self.timestamp_raw() as i64;
-        let seconds = ((timestamp >> 8) + KSUID_EPOCH) as i128;
-        let ns = (1_000_000 * (((timestamp & 0xFF) << 2) % 1_000)) as i128;
+        let seconds = (timestamp >> 8) + KSUID_EPOCH;
+        let ms = ((timestamp & 0xFF) << 2) % 1_000;
+        let val = seconds * 1_000 + ms;
 
-        OffsetDateTime::from_unix_timestamp_nanos(seconds * 1_000_000_000 + ns).unwrap()
+        T::from_millis(val).unwrap()
     }
 }
 
@@ -594,5 +760,89 @@ impl<'de> Deserialize<'de> for KsuidMs {
         D: Deserializer<'de>,
     {
         deserializer.deserialize_str(KsuidMsVisitor)
+    }
+}
+
+#[allow(clippy::inconsistent_digit_grouping)]
+#[cfg(test)]
+mod tests {
+    use super::{Ksuid, KsuidLike, KsuidMs, MinimalTimestamp, TimeStamp};
+
+    #[test]
+    fn test_minimal_timestamp() {
+        let ts = MinimalTimestamp::from_millis(1776798415_512).unwrap();
+        let truncated_s = MinimalTimestamp::from_secs(1776798415).unwrap();
+
+        let ksuid = Ksuid::new(Some(ts), None);
+        assert_eq!(ksuid.timestamp::<MinimalTimestamp>(), truncated_s);
+
+        let ksuid_ms = KsuidMs::new(Some(ts), None);
+        assert_eq!(ksuid_ms.timestamp::<MinimalTimestamp>(), ts);
+    }
+
+    #[cfg(feature = "time03")]
+    #[test]
+    fn test_time_support() {
+        let ts = time::OffsetDateTime::from_unix_timestamp_nanos(1776798415_512_123456).unwrap();
+        let truncated_s =
+            time::OffsetDateTime::from_unix_timestamp_nanos(1776798415_000_000000).unwrap();
+        let truncated_ms =
+            time::OffsetDateTime::from_unix_timestamp_nanos(1776798415_512_000000).unwrap();
+        let ksuid = Ksuid::new(Some(ts), None);
+        assert_eq!(ksuid.timestamp::<time::OffsetDateTime>(), truncated_s);
+
+        let ksuid_ms = KsuidMs::new(Some(ts), None);
+        assert_eq!(ksuid_ms.timestamp::<time::OffsetDateTime>(), truncated_ms);
+    }
+
+    #[cfg(feature = "chrono04")]
+    #[test]
+    fn test_chrono_support() {
+        use chrono::SubsecRound;
+
+        let ts = chrono::DateTime::<chrono::Utc>::from_timestamp_millis(1776798415_512).unwrap();
+        let truncated_ms = ts.trunc_subsecs(3);
+        let truncated_s = ts.trunc_subsecs(0);
+
+        let ksuid = Ksuid::new(Some(ts), None);
+        assert_eq!(
+            ksuid.timestamp::<chrono::DateTime<chrono::Utc>>(),
+            truncated_s
+        );
+
+        let ksuid_ms = KsuidMs::new(Some(ts), None);
+        assert_eq!(
+            ksuid_ms.timestamp::<chrono::DateTime<chrono::Utc>>(),
+            truncated_ms
+        );
+    }
+
+    #[cfg(feature = "jiff02")]
+    #[test]
+    fn test_jiff_support() {
+        use jiff::{RoundMode, Timestamp, TimestampRound, Unit};
+
+        let ts = Timestamp::from_microsecond(1776798415_512_123).unwrap();
+
+        let truncated_ms = ts
+            .round(
+                TimestampRound::new()
+                    .mode(RoundMode::Trunc)
+                    .smallest(Unit::Millisecond),
+            )
+            .unwrap();
+        let truncated_s = ts
+            .round(
+                TimestampRound::new()
+                    .mode(RoundMode::Trunc)
+                    .smallest(Unit::Second),
+            )
+            .unwrap();
+
+        let ksuid = Ksuid::new(Some(ts), None);
+        assert_eq!(ksuid.timestamp::<jiff::Timestamp>(), truncated_s);
+
+        let ksuid_ms = KsuidMs::new(Some(ts), None);
+        assert_eq!(ksuid_ms.timestamp::<jiff::Timestamp>(), truncated_ms);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -234,6 +234,26 @@ impl TimeStamp for MinimalTimestamp {
     }
 }
 
+/* The DefaultTimestamp alias is used for the methods like `.timestamp_millis()` that need
+ * some representation of time, but don't care which; we picked rather arbitrarily
+ * if you have multiple features enabled. */
+
+#[cfg(feature = "jiff02")]
+type DefaultTimestamp = jiff::Timestamp;
+
+#[cfg(all(not(feature = "jiff02"), feature = "chrono04"))]
+type DefaultTimestamp = chrono::Timestamp;
+
+#[cfg(all(not(feature = "jiff02"), not(feature = "chrono04"), feature = "time03"))]
+type DefaultTimestamp = time::OffsetDateTime;
+
+#[cfg(all(
+    not(feature = "jiff02"),
+    not(feature = "chrono04"),
+    not(feature = "time03")
+))]
+type DefaultTimestamp = MinimalTimestamp;
+
 /// K-Sortable Unique ID Trait
 ///
 /// This trait is implemented by all of the ksuid variants
@@ -313,7 +333,7 @@ pub trait KsuidLike {
     /// assert_eq!(ksuid.timestamp_seconds(), timestamp);
     /// ```
     fn timestamp_seconds(&self) -> i64 {
-        self.timestamp::<MinimalTimestamp>().as_secs()
+        self.timestamp::<DefaultTimestamp>().as_secs()
     }
 
     /// Get the payload portion of the ksuid
@@ -481,7 +501,7 @@ impl KsuidLike for Ksuid {
 
     fn from_seconds(timestamp: Option<i64>, payload: Option<&[u8]>) -> Self {
         let timestamp =
-            timestamp.unwrap_or_else(|| MinimalTimestamp::now().as_secs()) - KSUID_EPOCH;
+            timestamp.unwrap_or_else(|| DefaultTimestamp::now().as_secs()) - KSUID_EPOCH;
         Self::new_raw(timestamp as u32, payload)
     }
 
@@ -572,7 +592,7 @@ impl KsuidMs {
     /// let ksuid = KsuidMs::from_millis(Some(1_621_627_443_000), None);
     /// ```
     pub fn from_millis(timestamp: Option<i64>, payload: Option<&[u8]>) -> Self {
-        let timestamp_ms = timestamp.unwrap_or_else(|| MinimalTimestamp::now().as_millis());
+        let timestamp_ms = timestamp.unwrap_or_else(|| DefaultTimestamp::now().as_millis());
         let timestamp_s = (timestamp_ms / 1_000) - KSUID_EPOCH;
         let timestamp_ms = (timestamp_ms % 1_000) >> 2;
         let timestamp = ((timestamp_s << 8) & 0xFFFFFFFF00) | timestamp_ms;
@@ -590,7 +610,7 @@ impl KsuidMs {
     /// assert_eq!(ksuid.timestamp_millis(), timestamp);
     /// ```
     pub fn timestamp_millis(&self) -> i64 {
-        self.timestamp::<MinimalTimestamp>().as_millis()
+        self.timestamp::<DefaultTimestamp>().as_millis()
     }
 
     /// Get the raw timestamp value of the ksuid

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -63,24 +63,24 @@ fn test_ksuidms_reference_compat() -> Result<(), String> {
         let line = line.unwrap();
         let data_line: TestDataLine = serde_json::from_str(&line).unwrap();
         let ksuid = Ksuid::from_str(&data_line.ksuid).unwrap();
-        let timestamp: svix_ksuid::DefaultTimestamp = ksuid.timestamp();
+        let timestamp: svix_ksuid::MinimalTimestamp = ksuid.timestamp();
         let ksuidms = KsuidMs::new(
             Some(timestamp),
             Some(&ksuid.payload()[..KsuidMs::PAYLOAD_BYTES]),
         );
         assert_eq!(
-            ksuid.timestamp::<svix_ksuid::DefaultTimestamp>(),
-            ksuidms.timestamp::<svix_ksuid::DefaultTimestamp>()
+            ksuid.timestamp::<svix_ksuid::MinimalTimestamp>(),
+            ksuidms.timestamp::<svix_ksuid::MinimalTimestamp>()
         );
 
         let ksuidms_from = KsuidMs::new(
-            Some(ksuidms.timestamp::<svix_ksuid::DefaultTimestamp>()),
+            Some(ksuidms.timestamp::<svix_ksuid::MinimalTimestamp>()),
             Some(ksuidms.payload()),
         );
         assert_eq!(ksuidms_from.payload(), ksuidms.payload());
         assert_eq!(
-            ksuidms_from.timestamp::<svix_ksuid::DefaultTimestamp>(),
-            ksuidms.timestamp::<svix_ksuid::DefaultTimestamp>()
+            ksuidms_from.timestamp::<svix_ksuid::MinimalTimestamp>(),
+            ksuidms.timestamp::<svix_ksuid::MinimalTimestamp>()
         );
 
         let ksuidms = KsuidMs::from_str(&data_line.ksuid).unwrap();

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -63,19 +63,83 @@ fn test_ksuidms_reference_compat() -> Result<(), String> {
         let line = line.unwrap();
         let data_line: TestDataLine = serde_json::from_str(&line).unwrap();
         let ksuid = Ksuid::from_str(&data_line.ksuid).unwrap();
+        let timestamp: svix_ksuid::DefaultTimestamp = ksuid.timestamp();
         let ksuidms = KsuidMs::new(
-            Some(ksuid.timestamp()),
+            Some(timestamp),
             Some(&ksuid.payload()[..KsuidMs::PAYLOAD_BYTES]),
         );
-        assert_eq!(ksuid.timestamp(), ksuidms.timestamp());
+        assert_eq!(
+            ksuid.timestamp::<svix_ksuid::DefaultTimestamp>(),
+            ksuidms.timestamp::<svix_ksuid::DefaultTimestamp>()
+        );
 
-        let ksuidms_from = KsuidMs::new(Some(ksuidms.timestamp()), Some(ksuidms.payload()));
+        let ksuidms_from = KsuidMs::new(
+            Some(ksuidms.timestamp::<svix_ksuid::DefaultTimestamp>()),
+            Some(ksuidms.payload()),
+        );
         assert_eq!(ksuidms_from.payload(), ksuidms.payload());
-        assert_eq!(ksuidms_from.timestamp(), ksuidms.timestamp());
+        assert_eq!(
+            ksuidms_from.timestamp::<svix_ksuid::DefaultTimestamp>(),
+            ksuidms.timestamp::<svix_ksuid::DefaultTimestamp>()
+        );
 
         let ksuidms = KsuidMs::from_str(&data_line.ksuid).unwrap();
-        let timediff = ksuidms.timestamp() - ksuid.timestamp();
-        assert!(timediff.whole_milliseconds().abs() <= 1_000);
+        #[cfg(feature = "time03")]
+        {
+            let timediff = ksuidms.timestamp::<time::OffsetDateTime>()
+                - ksuid.timestamp::<time::OffsetDateTime>();
+            assert!(timediff.whole_milliseconds().abs() <= 1_000);
+
+            assert_eq!(
+                ksuid.timestamp::<svix_ksuid::MinimalTimestamp>().as_secs(),
+                ksuid.timestamp::<time::OffsetDateTime>().as_secs()
+            );
+
+            assert_eq!(
+                ksuidms
+                    .timestamp::<svix_ksuid::MinimalTimestamp>()
+                    .as_millis(),
+                ksuidms.timestamp::<time::OffsetDateTime>().as_millis()
+            );
+        }
+        #[cfg(feature = "chrono04")]
+        {
+            let timediff = ksuidms.timestamp::<chrono::DateTime<chrono::Utc>>()
+                - ksuid.timestamp::<chrono::DateTime<chrono::Utc>>();
+            assert!(timediff.num_milliseconds().abs() <= 1_000);
+
+            assert_eq!(
+                ksuid.timestamp::<svix_ksuid::MinimalTimestamp>().as_secs(),
+                ksuid.timestamp::<chrono::DateTime<chrono::Utc>>().as_secs()
+            );
+
+            assert_eq!(
+                ksuidms
+                    .timestamp::<svix_ksuid::MinimalTimestamp>()
+                    .as_millis(),
+                ksuidms
+                    .timestamp::<chrono::DateTime<chrono::Utc>>()
+                    .as_millis()
+            );
+        }
+        #[cfg(feature = "jiff02")]
+        {
+            let timediff =
+                ksuidms.timestamp::<jiff::Timestamp>() - ksuid.timestamp::<jiff::Timestamp>();
+            assert!(timediff.total(jiff::Unit::Millisecond).unwrap() < 1_000.0);
+
+            assert_eq!(
+                ksuid.timestamp::<svix_ksuid::MinimalTimestamp>().as_secs(),
+                ksuid.timestamp::<jiff::Timestamp>().as_secs()
+            );
+
+            assert_eq!(
+                ksuidms
+                    .timestamp::<svix_ksuid::MinimalTimestamp>()
+                    .as_millis(),
+                ksuidms.timestamp::<jiff::Timestamp>().as_millis()
+            );
+        }
         assert_eq!(ksuidms.to_base62(), data_line.ksuid);
     }
     Ok(())
@@ -87,8 +151,29 @@ fn test_ksuidms_corner_cases() -> Result<(), String> {
     let buf = [0xFFu8; 16];
     let ksuid = Ksuid::from_seconds(Some(40_000), Some(&buf));
     let ksuidms = KsuidMs::from_bytes(*ksuid.bytes());
-    let timediff = ksuidms.timestamp() - ksuid.timestamp();
-    assert!(timediff.whole_milliseconds().abs() <= 1_000);
+
+    assert_eq!(ksuidms.timestamp_millis(), 4295007296020);
+
+    #[cfg(feature = "time03")]
+    {
+        let timediff =
+            ksuidms.timestamp::<time::OffsetDateTime>() - ksuid.timestamp::<time::OffsetDateTime>();
+        assert!(timediff.whole_milliseconds().abs() <= 1_000);
+    }
+
+    #[cfg(feature = "chrono04")]
+    {
+        let timediff = ksuidms.timestamp::<chrono::DateTime<chrono::Utc>>()
+            - ksuid.timestamp::<chrono::DateTime<chrono::Utc>>();
+        assert!(timediff.num_milliseconds().abs() <= 1_000);
+    }
+
+    #[cfg(feature = "jiff02")]
+    {
+        let timediff =
+            ksuidms.timestamp::<jiff::Timestamp>() - ksuid.timestamp::<jiff::Timestamp>();
+        assert!(timediff.total(jiff::Unit::Millisecond).unwrap() < 1_000.0);
+    }
     Ok(())
 }
 
@@ -109,11 +194,11 @@ fn test_ordering() -> Result<(), String> {
 fn test_hash() {
     // given
     let mut set = HashSet::new();
-    let ksuid1 = Ksuid::new(None, None);
-    let ksuid2 = Ksuid::new(None, None);
+    let ksuid1 = Ksuid::now(None);
+    let ksuid2 = Ksuid::now(None);
     // when
-    set.insert(ksuid1.clone());
-    set.insert(ksuid2.clone());
+    set.insert(ksuid1);
+    set.insert(ksuid2);
     // then
     assert_eq!(set.len(), 2);
     assert!(set.contains(&ksuid1));
@@ -124,11 +209,11 @@ fn test_hash() {
 fn test_hash_ms() {
     // given
     let mut set = HashSet::new();
-    let ksuidms1 = KsuidMs::new(None, None);
-    let ksuidms2 = KsuidMs::new(None, None);
+    let ksuidms1 = KsuidMs::now(None);
+    let ksuidms2 = KsuidMs::now(None);
     // when
-    set.insert(ksuidms1.clone());
-    set.insert(ksuidms2.clone());
+    set.insert(ksuidms1);
+    set.insert(ksuidms2);
     // then
     assert_eq!(set.len(), 2);
     assert!(set.contains(&ksuidms1));


### PR DESCRIPTION
I was looking at one of our other applications, and saw that upgrading `svix-ksuid` would bring in the `time` crate, which I didn't want.

This PR makes it so that this crate supports all of `time`, `chrono`, and `jiff` depending on its feature flags.

Other changes:

 - adds `KsuidLike::now()` as a simpler alternative to `KsuidLike::new()` now that new has generics
 - bumps to Rust 2024 edition
 - sets the MSRV
 - set up `cargo-deny`
 - many changes to CI