### PR TITLE
remove security badge from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ A pure Rust and fully tested KSUID implementation
 ![GitHub tag](https://img.shields.io/github/tag/svix/rust-ksuid.svg)
 [![Crates.io](https://img.shields.io/crates/v/svix-ksuid)](https://crates.io/crates/svix-ksuid)
 [![Build Status](https://github.com/svix/rust-ksuid/workflows/CI/badge.svg)](https://github.com/svix/rust-ksuid/actions)
-[![Security audit](https://github.com/svix/rust-ksuid/actions/workflows/security.yml/badge.svg)](https://github.com/svix/rust-ksuid/actions/workflows/security.yml)
 [![docs.rs](https://docs.rs/svix-ksuid/badge.svg)](https://docs.rs/svix-ksuid/)
 [![License](https://img.shields.io/badge/license-MIT-brightgreen.svg)](LICENSE)
 [![Join our slack](https://img.shields.io/badge/Slack-join%20the%20community-blue?logo=slack&style=social)](https://www.svix.com/slack/)


### PR DESCRIPTION
I merged `security.yml` into the main CI workflow, so this badge goes nowhere