### PR TITLE
time: replace MinimalTimestamp with just good old SystemTime

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased changes
+* Remove internal `MinimalTimestamp` type and use [`std::time::SystemTime`](https://doc.rust-lang.org/std/time/struct.SystemTime.html) as the fallback timestamp
+* Rename `TimeStamp` trait to `Timestamp`
+
 ## Version 0.9.0
 * Bump MSRV to 1.88.0
 * Upgrade to Rust edition 2024

--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ And they both implement the same `KsuidLike` trait.
 * `chrono04` - accept timestamps as the `chrono::DateTime<chrono::Utc>` type from the [chrono](https://crates.io/crates/chrono) (0.4.x) crate
 * `jiff02` - accept timestamps as the `jiff::Timestamp` type from the [jiff](https://crates.io/crates/jiff) (0.2.x) crate
 
+If none of `time03`, `chrono04`, or `jiff02` are enabled, then timestamps will be represented using [`std::time::SystemTime`](https://doc.rust-lang.org/std/time/struct.SystemTime.html) and time values below 1970-01-01 will panic.
+
 Make sure to enable like this:
 ```toml
 [dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,8 +63,12 @@
 //! All rights reserved to the [Svix webhooks service](https://www.svix.com).
 
 use core::fmt;
-use std::hash::{Hash, Hasher};
-use std::{error, str::FromStr};
+use std::{
+    error,
+    hash::{Hash, Hasher},
+    str::FromStr,
+    time::SystemTime,
+};
 
 use byteorder::{BigEndian, ByteOrder};
 
@@ -212,25 +216,21 @@ impl TimeStamp for jiff::Timestamp {
     }
 }
 
-#[allow(unused)]
-/// A minimal representation of a timestamp (as integral milliseconds since UNIX_EPOCH) suitable
-/// for use if none of jiff02, chrono04, nor time03 are enabled
-#[derive(Debug, Clone, Copy, PartialOrd, Ord, PartialEq, Eq)]
-pub struct MinimalTimestamp(i64);
-
-impl TimeStamp for MinimalTimestamp {
+impl TimeStamp for SystemTime {
     type ConstructionError = std::convert::Infallible;
 
     fn now() -> Self {
-        Self(std::time::UNIX_EPOCH.elapsed().unwrap().as_millis() as _)
+        SystemTime::now()
     }
 
     fn from_millis(val: i64) -> Result<Self, std::convert::Infallible> {
-        Ok(Self(val))
+        Ok(std::time::UNIX_EPOCH + std::time::Duration::from_millis(val as _))
     }
 
     fn as_millis(&self) -> i64 {
-        self.0
+        self.duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_millis() as _
     }
 }
 
@@ -252,7 +252,7 @@ type DefaultTimestamp = time::OffsetDateTime;
     not(feature = "chrono04"),
     not(feature = "time03")
 ))]
-type DefaultTimestamp = MinimalTimestamp;
+type DefaultTimestamp = SystemTime;
 
 /// K-Sortable Unique ID Trait
 ///
@@ -281,9 +281,10 @@ pub trait KsuidLike {
     ///
     /// # Examples
     /// ```
+    /// use std::time::SystemTime;
     /// use svix_ksuid::*;
     ///
-    /// let ts = MinimalTimestamp::from_millis(1776798415000).unwrap();
+    /// let ts = SystemTime::from_millis(1776798415000).unwrap();
     /// let ksuid = Ksuid::new(Some(ts), None);
     /// ```
     fn new<T: TimeStamp>(timestamp: Option<T>, payload: Option<&[u8]>) -> Self::Type;
@@ -297,7 +298,7 @@ pub trait KsuidLike {
     /// let ksuid = Ksuid::now(None);
     /// ```
     fn now(payload: Option<&[u8]>) -> Self::Type {
-        Self::new(None::<MinimalTimestamp>, payload)
+        Self::new(None::<DefaultTimestamp>, payload)
     }
 
     /// Creates new Ksuid with specified timestamp (in seconds) and optional payload
@@ -314,11 +315,12 @@ pub trait KsuidLike {
     ///
     /// # Examples
     /// ```
+    /// use std::time::SystemTime;
     /// use svix_ksuid::*;
     ///
-    /// let now = MinimalTimestamp::now();
+    /// let now = SystemTime::now();
     /// let ksuid = Ksuid::new(Some(now), None);
-    /// assert_eq!(now.as_secs(), ksuid.timestamp::<MinimalTimestamp>().as_secs());
+    /// assert_eq!(now.as_secs(), ksuid.timestamp::<SystemTime>().as_secs());
     /// ```
     fn timestamp<T: TimeStamp>(&self) -> T;
 
@@ -478,9 +480,10 @@ impl Ksuid {
     ///
     /// # Examples
     /// ```
+    /// use std::time::SystemTime;
     /// use svix_ksuid::*;
     ///
-    /// let ts = MinimalTimestamp::from_millis(1776798415000).unwrap();
+    /// let ts = SystemTime::from_millis(1776798415000).unwrap();
     /// let ksuid = Ksuid::new(Some(ts), None);
     /// let raw = ksuid.timestamp_raw();
     /// ```
@@ -770,18 +773,19 @@ impl<'de> Deserialize<'de> for KsuidMs {
 #[allow(clippy::inconsistent_digit_grouping)]
 #[cfg(test)]
 mod tests {
-    use super::{Ksuid, KsuidLike, KsuidMs, MinimalTimestamp, TimeStamp};
+    use super::{Ksuid, KsuidLike, KsuidMs, TimeStamp};
+    use std::time::SystemTime;
 
     #[test]
-    fn test_minimal_timestamp() {
-        let ts = MinimalTimestamp::from_millis(1776798415_512).unwrap();
-        let truncated_s = MinimalTimestamp::from_secs(1776798415).unwrap();
+    fn test_systemtime_timestamp() {
+        let ts = SystemTime::from_millis(1776798415_512).unwrap();
+        let truncated_s = SystemTime::from_secs(1776798415).unwrap();
 
         let ksuid = Ksuid::new(Some(ts), None);
-        assert_eq!(ksuid.timestamp::<MinimalTimestamp>(), truncated_s);
+        assert_eq!(ksuid.timestamp::<SystemTime>(), truncated_s);
 
         let ksuid_ms = KsuidMs::new(Some(ts), None);
-        assert_eq!(ksuid_ms.timestamp::<MinimalTimestamp>(), ts);
+        assert_eq!(ksuid_ms.timestamp::<SystemTime>(), ts);
     }
 
     #[cfg(feature = "time03")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -216,17 +216,59 @@ impl Timestamp for jiff::Timestamp {
     }
 }
 
-impl Timestamp for SystemTime {
-    type ConstructionError = std::convert::Infallible;
+#[derive(Debug, Clone)]
+pub enum InvalidSystemTimeError {
+    BeforeUnixEpoch,
+}
 
+impl std::fmt::Display for InvalidSystemTimeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::BeforeUnixEpoch => write!(f, "time is before the unix epoch"),
+        }
+    }
+}
+
+impl std::error::Error for InvalidSystemTimeError {}
+
+impl Timestamp for SystemTime {
+    type ConstructionError = InvalidSystemTimeError;
+
+    /// Return the current SystemTime
     fn now() -> Self {
         SystemTime::now()
     }
 
-    fn from_millis(val: i64) -> Result<Self, std::convert::Infallible> {
-        Ok(std::time::UNIX_EPOCH + std::time::Duration::from_millis(val as _))
+    /// Construct a new SystemTime from a number of seconds since the Unix epoch
+    fn from_secs(val: i64) -> Result<Self, Self::ConstructionError> {
+        let unsigned = match val.try_into() {
+            Ok(v) => v,
+            Err(_) => return Err(InvalidSystemTimeError::BeforeUnixEpoch),
+        };
+        Ok(std::time::UNIX_EPOCH + std::time::Duration::from_secs(unsigned))
     }
 
+    /// Construct a new SystemTime from a number of milliseconds since the Unix epoch
+    fn from_millis(val: i64) -> Result<Self, Self::ConstructionError> {
+        let unsigned = match val.try_into() {
+            Ok(v) => v,
+            Err(_) => return Err(InvalidSystemTimeError::BeforeUnixEpoch),
+        };
+        Ok(std::time::UNIX_EPOCH + std::time::Duration::from_millis(unsigned))
+    }
+
+    /// Convert this SystemTime to an integral number of seconds since the unix epoch
+    ///
+    /// Panics if the current time is before the Unix epoch (1970-01-01)
+    fn as_secs(&self) -> i64 {
+        self.duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs() as _
+    }
+
+    /// Convert this SystemTime to an integral number of milliseconds since the unix epoch
+    ///
+    /// Panics if the current time is before the Unix epoch (1970-01-01)
     fn as_millis(&self) -> i64 {
         self.duration_since(std::time::UNIX_EPOCH)
             .unwrap()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,7 +99,7 @@ impl error::Error for Error {
     }
 }
 
-pub trait TimeStamp: Sized {
+pub trait Timestamp: Sized {
     type ConstructionError: std::error::Error + Sized;
 
     fn now() -> Self;
@@ -118,7 +118,7 @@ pub trait TimeStamp: Sized {
 }
 
 #[cfg(feature = "time03")]
-impl TimeStamp for time::OffsetDateTime {
+impl Timestamp for time::OffsetDateTime {
     type ConstructionError = time::error::ComponentRange;
 
     fn now() -> Self {
@@ -167,7 +167,7 @@ impl std::error::Error for InvalidChronoTimestamp {
 }
 
 #[cfg(feature = "chrono04")]
-impl TimeStamp for chrono::DateTime<chrono::Utc> {
+impl Timestamp for chrono::DateTime<chrono::Utc> {
     type ConstructionError = InvalidChronoTimestamp;
 
     fn now() -> Self {
@@ -192,7 +192,7 @@ impl TimeStamp for chrono::DateTime<chrono::Utc> {
 }
 
 #[cfg(feature = "jiff02")]
-impl TimeStamp for jiff::Timestamp {
+impl Timestamp for jiff::Timestamp {
     type ConstructionError = jiff::Error;
 
     fn now() -> Self {
@@ -216,7 +216,7 @@ impl TimeStamp for jiff::Timestamp {
     }
 }
 
-impl TimeStamp for SystemTime {
+impl Timestamp for SystemTime {
     type ConstructionError = std::convert::Infallible;
 
     fn now() -> Self {
@@ -287,7 +287,7 @@ pub trait KsuidLike {
     /// let ts = SystemTime::from_millis(1776798415000).unwrap();
     /// let ksuid = Ksuid::new(Some(ts), None);
     /// ```
-    fn new<T: TimeStamp>(timestamp: Option<T>, payload: Option<&[u8]>) -> Self::Type;
+    fn new<T: Timestamp>(timestamp: Option<T>, payload: Option<&[u8]>) -> Self::Type;
 
     /// Creates a new Ksuid at the current timestamp, with an optional payload
     ///
@@ -322,7 +322,7 @@ pub trait KsuidLike {
     /// let ksuid = Ksuid::new(Some(now), None);
     /// assert_eq!(now.as_secs(), ksuid.timestamp::<SystemTime>().as_secs());
     /// ```
-    fn timestamp<T: TimeStamp>(&self) -> T;
+    fn timestamp<T: Timestamp>(&self) -> T;
 
     /// Get the timestamp portion of the ksuid in seconds
     ///
@@ -497,7 +497,7 @@ impl KsuidLike for Ksuid {
     const TIMESTAMP_BYTES: usize = 4;
     const PAYLOAD_BYTES: usize = 16;
 
-    fn new<T: TimeStamp>(timestamp: Option<T>, payload: Option<&[u8]>) -> Self {
+    fn new<T: Timestamp>(timestamp: Option<T>, payload: Option<&[u8]>) -> Self {
         let timestamp = timestamp.map(|x| x.as_secs());
         Self::from_seconds(timestamp, payload)
     }
@@ -516,7 +516,7 @@ impl KsuidLike for Ksuid {
         &self.0
     }
 
-    fn timestamp<T: TimeStamp>(&self) -> T {
+    fn timestamp<T: Timestamp>(&self) -> T {
         let timestamp = self.timestamp_raw() as i64 + KSUID_EPOCH;
         T::from_secs(timestamp).unwrap()
     }
@@ -638,7 +638,7 @@ impl KsuidLike for KsuidMs {
     const TIMESTAMP_BYTES: usize = 5;
     const PAYLOAD_BYTES: usize = 15;
 
-    fn new<T: TimeStamp>(timestamp: Option<T>, payload: Option<&[u8]>) -> Self {
+    fn new<T: Timestamp>(timestamp: Option<T>, payload: Option<&[u8]>) -> Self {
         let timestamp = timestamp.map(|x| x.as_millis());
         Self::from_millis(timestamp, payload)
     }
@@ -656,7 +656,7 @@ impl KsuidLike for KsuidMs {
         &self.0
     }
 
-    fn timestamp<T: TimeStamp>(&self) -> T {
+    fn timestamp<T: Timestamp>(&self) -> T {
         let timestamp = self.timestamp_raw() as i64;
         let seconds = (timestamp >> 8) + KSUID_EPOCH;
         let ms = ((timestamp & 0xFF) << 2) % 1_000;
@@ -773,7 +773,7 @@ impl<'de> Deserialize<'de> for KsuidMs {
 #[allow(clippy::inconsistent_digit_grouping)]
 #[cfg(test)]
 mod tests {
-    use super::{Ksuid, KsuidLike, KsuidMs, TimeStamp};
+    use super::{Ksuid, KsuidLike, KsuidMs, Timestamp};
     use std::time::SystemTime;
 
     #[test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -8,6 +8,7 @@ use std::{
     io::{self, BufRead},
     path::PathBuf,
     str::FromStr,
+    time::SystemTime,
 };
 use svix_ksuid::*;
 
@@ -63,24 +64,24 @@ fn test_ksuidms_reference_compat() -> Result<(), String> {
         let line = line.unwrap();
         let data_line: TestDataLine = serde_json::from_str(&line).unwrap();
         let ksuid = Ksuid::from_str(&data_line.ksuid).unwrap();
-        let timestamp: svix_ksuid::MinimalTimestamp = ksuid.timestamp();
+        let timestamp: SystemTime = ksuid.timestamp();
         let ksuidms = KsuidMs::new(
             Some(timestamp),
             Some(&ksuid.payload()[..KsuidMs::PAYLOAD_BYTES]),
         );
         assert_eq!(
-            ksuid.timestamp::<svix_ksuid::MinimalTimestamp>(),
-            ksuidms.timestamp::<svix_ksuid::MinimalTimestamp>()
+            ksuid.timestamp::<SystemTime>(),
+            ksuidms.timestamp::<SystemTime>()
         );
 
         let ksuidms_from = KsuidMs::new(
-            Some(ksuidms.timestamp::<svix_ksuid::MinimalTimestamp>()),
+            Some(ksuidms.timestamp::<SystemTime>()),
             Some(ksuidms.payload()),
         );
         assert_eq!(ksuidms_from.payload(), ksuidms.payload());
         assert_eq!(
-            ksuidms_from.timestamp::<svix_ksuid::MinimalTimestamp>(),
-            ksuidms.timestamp::<svix_ksuid::MinimalTimestamp>()
+            ksuidms_from.timestamp::<SystemTime>(),
+            ksuidms.timestamp::<SystemTime>()
         );
 
         let ksuidms = KsuidMs::from_str(&data_line.ksuid).unwrap();
@@ -91,14 +92,12 @@ fn test_ksuidms_reference_compat() -> Result<(), String> {
             assert!(timediff.whole_milliseconds().abs() <= 1_000);
 
             assert_eq!(
-                ksuid.timestamp::<svix_ksuid::MinimalTimestamp>().as_secs(),
+                ksuid.timestamp::<SystemTime>().as_secs(),
                 ksuid.timestamp::<time::OffsetDateTime>().as_secs()
             );
 
             assert_eq!(
-                ksuidms
-                    .timestamp::<svix_ksuid::MinimalTimestamp>()
-                    .as_millis(),
+                ksuidms.timestamp::<SystemTime>().as_millis(),
                 ksuidms.timestamp::<time::OffsetDateTime>().as_millis()
             );
         }
@@ -109,14 +108,12 @@ fn test_ksuidms_reference_compat() -> Result<(), String> {
             assert!(timediff.num_milliseconds().abs() <= 1_000);
 
             assert_eq!(
-                ksuid.timestamp::<svix_ksuid::MinimalTimestamp>().as_secs(),
+                ksuid.timestamp::<SystemTime>().as_secs(),
                 ksuid.timestamp::<chrono::DateTime<chrono::Utc>>().as_secs()
             );
 
             assert_eq!(
-                ksuidms
-                    .timestamp::<svix_ksuid::MinimalTimestamp>()
-                    .as_millis(),
+                ksuidms.timestamp::<SystemTime>().as_millis(),
                 ksuidms
                     .timestamp::<chrono::DateTime<chrono::Utc>>()
                     .as_millis()
@@ -129,14 +126,12 @@ fn test_ksuidms_reference_compat() -> Result<(), String> {
             assert!(timediff.total(jiff::Unit::Millisecond).unwrap() < 1_000.0);
 
             assert_eq!(
-                ksuid.timestamp::<svix_ksuid::MinimalTimestamp>().as_secs(),
+                ksuid.timestamp::<SystemTime>().as_secs(),
                 ksuid.timestamp::<jiff::Timestamp>().as_secs()
             );
 
             assert_eq!(
-                ksuidms
-                    .timestamp::<svix_ksuid::MinimalTimestamp>()
-                    .as_millis(),
+                ksuidms.timestamp::<SystemTime>().as_millis(),
                 ksuidms.timestamp::<jiff::Timestamp>().as_millis()
             );
         }


### PR DESCRIPTION
It's a bit wider (since it wraps a Timespec, which is 96 bits wide instead of a u64), but this should simplify integration with std-only consumers.

This is a breaking change relative to 0.9.0