### PR TITLE
ci: Group dependabot GHA updates into one PR per week

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,11 @@ updates:
     open-pull-requests-limit: 2
     cooldown:
       default-days: 3
+    groups:
+      workflows:
+        applies-to: version-updates
+        patterns:
+          - '*'
     schedule:
       interval: "weekly"
       day: "wednesday"


### PR DESCRIPTION
Same as in other repos.